### PR TITLE
fix: to support jsx syntax

### DIFF
--- a/src/commands/SearchCommand.ts
+++ b/src/commands/SearchCommand.ts
@@ -31,7 +31,7 @@ function filterViaGitignore(uris: Uri[]) {
 async function findMatches(files: Uri[], query: string): Promise<SearchResultsByFilePath> {
   const results = await Promise.all(files.map(async (file) => {
     const contents = (await workspace.fs.readFile(file)).toString();
-    const ast = parse(contents);
+    const ast = parse(contents, { jsx: true });
 
     try {
       const matches = esquery.query(ast as Node, query);


### PR DESCRIPTION
JSX syntax is not supported at the moment and you can't search such files.

Maybe we could add this as a option but I don't know how todo it.